### PR TITLE
Add support for using a single SQS queue per environment

### DIFF
--- a/after_write_hooks/config/sqs.conf
+++ b/after_write_hooks/config/sqs.conf
@@ -1,11 +1,3 @@
-queues:
-    default:
-      - access_key_id: AWS_ACCESS_KEY_ID
-        secret_access_key: AWS_SECRET_ACCESS_KEY
-        region: us-west-2
-
-    sent_email:
-      - name: SQS_QUEUE_NAME
-        access_key_id: AWS_ACCESS_KEY_ID
-        secret_access_key: AWS_SECRET_ACCESS_KEY
-        region: us-west-2
+access_key_id: AWS_ACCESS_KEY_ID
+secret_access_key: AWS_SECRET_ACCESS_KEY
+region: us-west-2

--- a/after_write_hooks/sqs_single_queue.rb
+++ b/after_write_hooks/sqs_single_queue.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'aws-sdk'
+require 'json'
+require 'yaml'
+
+module AfterWriteHooks
+  class SQS
+    QUEUE_SUFFIX = 'redshift_etl'
+
+    # @param [string] config_file_path
+    #   The config file contains the access key, secret key, and region for the SQS queue
+    #   Example: "/etc/td-agent/sqs.conf"
+    # @param [string] s3_bucket
+    #   Example: "change-fluentd-production"
+    # @param [string] s3_path
+    #   The key in S3
+    #   Example: "events/petition_view/production-change_main_fluentd_hub-00/2015/05/28/21_0.json"
+    # @param [string] environment
+    #   Example: "development", "staging", "production"
+    # @param [string] event_name
+    #   Example: "petition_view", "create_petition"
+    def self.run(config_file_path, s3_bucket, s3_path, environment, event_name)
+      queue_config = YAML.load_file(config_file_path)
+      queue_name = "#{environment}-#{QUEUE_SUFFIX}" # production-redshift_etl, staging-redshift_etl, etc.
+
+      sqs = AWS::SQS.new(
+        access_key_id: queue_config['access_key_id'],
+        secret_access_key: queue_config['secret_access_key'],
+        region: queue_config['region']
+      )
+      queue = sqs.queues.named(queue_name)
+      queue.send_message({
+          s3_bucket: s3_bucket,
+          s3_path: s3_path,
+          event_name: event_name
+        }.to_json)
+    end
+  end
+end
+
+if ARGV.length > 1
+  AfterWriteHooks::SQS.run(*ARGV)
+end

--- a/lib/fluent/plugin/out_s3_with_sqs_single_queue.rb
+++ b/lib/fluent/plugin/out_s3_with_sqs_single_queue.rb
@@ -1,0 +1,233 @@
+module Fluent
+
+  require 'fluent/mixin/config_placeholders'
+
+  class S3WithSqsOutput < Fluent::TimeSlicedOutput
+    Fluent::Plugin.register_output('s3_with_sqs_single_queue', self)
+
+    unless method_defined?(:log)
+      define_method(:log) { $log }
+    end
+
+    def initialize
+      super
+      require 'aws-sdk'
+      require 'zlib'
+      require 'time'
+      require 'tempfile'
+      require 'open3'
+
+      @use_ssl = true
+    end
+
+    config_param :path, :string, :default => ""
+    config_param :time_format, :string, :default => nil
+
+    include SetTagKeyMixin
+    config_set_default :include_tag_key, false
+
+    include SetTimeKeyMixin
+    config_set_default :include_time_key, false
+
+    config_param :aws_key_id, :string, :default => nil
+    config_param :aws_sec_key, :string, :default => nil
+    config_param :s3_bucket, :string
+    config_param :s3_endpoint, :string, :default => nil
+    config_param :s3_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"
+    config_param :store_as, :string, :default => "gzip"
+    config_param :command_parameter, :string, :default => nil
+    config_param :auto_create_bucket, :bool, :default => true
+    config_param :check_apikey_on_start, :bool, :default => true
+    config_param :proxy_uri, :string, :default => nil
+    config_param :reduced_redundancy, :bool, :default => false
+    config_param :environment, :string, :default => "development"
+    config_param :tag_name, :string
+    config_param :after_flush, :default => [] do |val|
+      val.split(',').collect { |v| v.strip }
+    end
+    config_param :after_flush_config, :default => [] do |val|
+      val.split(',').collect { |v| v.strip }
+    end
+
+    attr_reader :bucket
+
+    include Fluent::Mixin::ConfigPlaceholders
+
+    def placeholders
+      [:percent]
+    end
+
+    def configure(conf)
+      super
+
+      if format_json = conf['format_json']
+        @format_json = true
+      else
+        @format_json = false
+      end
+
+      if use_ssl = conf['use_ssl']
+        if use_ssl.empty?
+          @use_ssl = true
+        else
+          @use_ssl = Config.bool_value(use_ssl)
+          if @use_ssl.nil?
+            raise ConfigError, "'true' or 'false' is required for use_ssl option on s3 output"
+          end
+        end
+      end
+
+      @ext, @mime_type = case @store_as
+                           when 'gzip'
+                             ['gz', 'application/x-gzip']
+                           when 'lzo'
+                             check_command('lzop', 'LZO')
+                             @command_parameter = '-qf1' if @command_parameter.nil?
+                             ['lzo', 'application/x-lzop']
+                           when 'lzma2'
+                             check_command('xz', 'LZMA2')
+                             @command_parameter = '-qf0' if @command_parameter.nil?
+                             ['xz', 'application/x-xz']
+                           when 'json'
+                             ['json', 'application/json']
+                           else
+                             ['txt', 'text/plain']
+                         end
+
+      @timef = TimeFormatter.new(@time_format, @localtime)
+
+      if @localtime
+        @path_slicer = Proc.new { |path|
+          Time.now.strftime(path)
+        }
+      else
+        @path_slicer = Proc.new { |path|
+          Time.now.utc.strftime(path)
+        }
+      end
+
+    end
+
+    def start
+      super
+      options = {}
+      if @aws_key_id && @aws_sec_key
+        options[:access_key_id] = @aws_key_id
+        options[:secret_access_key] = @aws_sec_key
+      end
+      options[:s3_endpoint] = @s3_endpoint if @s3_endpoint
+      options[:proxy_uri] = @proxy_uri if @proxy_uri
+      options[:use_ssl] = @use_ssl
+
+      @s3 = AWS::S3.new(options)
+      @bucket = @s3.buckets[@s3_bucket]
+
+      check_apikeys if @check_apikey_on_start
+      ensure_bucket
+    end
+
+    def format(tag, time, record)
+      if @include_time_key || !@format_json
+        time_str = @timef.format(time)
+      end
+
+      # copied from each mixin because current TimeSlicedOutput can't support mixins.
+      if @include_tag_key
+        record[@tag_key] = tag
+      end
+      if @include_time_key
+        record[@time_key] = time_str
+      end
+
+      if @format_json
+        Yajl.dump(record) + "\n"
+      else
+        "#{time_str}\t#{tag}\t#{Yajl.dump(record)}\n"
+      end
+    end
+
+    def write(chunk)
+      i = 0
+
+      begin
+        path = @path_slicer.call(@path)
+        values_for_s3_object_key = {
+          "path" => path,
+          "time_slice" => chunk.key,
+          "file_extension" => @ext,
+          "index" => i
+        }
+        s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) { |expr|
+          values_for_s3_object_key[expr[2...expr.size-1]]
+        }
+        i += 1
+      end while @bucket.objects[s3path].exists?
+
+      tmp = Tempfile.new("s3-")
+      begin
+        if @store_as == "gzip"
+          w = Zlib::GzipWriter.new(tmp)
+          chunk.write_to(w)
+          w.close
+        elsif @store_as == "lzo"
+          w = Tempfile.new("chunk-tmp")
+          chunk.write_to(w)
+          w.close
+          tmp.close
+          # We don't check the return code because we can't recover lzop failure.
+          system "lzop #{@command_parameter} -o #{tmp.path} #{w.path}"
+        elsif @store_as == "lzma2"
+          w = Tempfile.new("chunk-xz-tmp")
+          chunk.write_to(w)
+          w.close
+          tmp.close
+          system "xz #{@command_parameter} -c #{w.path} > #{tmp.path}"
+        else
+          chunk.write_to(tmp)
+          tmp.close
+        end
+        @bucket.objects[s3path].write(Pathname.new(tmp.path), { :content_type => @mime_type,
+            :reduced_redundancy => @reduced_redundancy })
+
+        @after_flush.each_with_index do |after_flush_cmd, i|
+          config_file = @after_flush_config[i]
+          after_hook_succeeded = system(after_flush_cmd, config_file, @s3_bucket, s3path, @environment, @tag_name)
+          log.info "After flush command \"#{after_flush_cmd} #{config_file} #{@s3_bucket} #{s3path}\" #{@tag_name} exited with non-zero status, ignoring." unless after_hook_succeeded
+        end
+      ensure
+        tmp.close(true) rescue nil
+        w.close rescue nil
+        w.unlink rescue nil
+      end
+    end
+
+    private
+
+    def ensure_bucket
+      if !@bucket.exists?
+        if @auto_create_bucket
+          log.info "Creating bucket #{@s3_bucket} on #{@s3_endpoint}"
+          @s3.buckets.create(@s3_bucket)
+        else
+          raise "The specified bucket does not exist: bucket = #{@s3_bucket}"
+        end
+      end
+    end
+
+    def check_apikeys
+      @bucket.empty?
+    rescue
+      raise "aws_key_id or aws_sec_key is invalid. Please check your configuration"
+    end
+
+    def check_command(command, algo)
+      begin
+        Open3.capture3("#{command} -V")
+      rescue Errno::ENOENT
+        raise ConfigError, "'#{command}' utility must be in PATH for #{algo} compression"
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
Turns out merging this to master was a really bad idea, since a chef-client run on production automatically pulls master onto the fluentd hubs. I've updated the PR to include brand new files instead of updating existing one, so we can merge this safely and then transition to the new files when ready
